### PR TITLE
Update package.json `license` field to `BSD-2-Clause`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pct",
     "encode"
   ],
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "testling": {
     "files": "test.js",
     "browsers": {


### PR DESCRIPTION
The current license is causing `spdx-expression-parse` [1] to fail to parse this package.

`BSD` is no longer a valid license - it isn't in the list of SPDX licenses: https://spdx.org/licenses/

`BSD` used to be the default for `npm init` [2],
but now it's no longer allowed:
> `Sorry, license should be a valid SPDX license expression`

`BSD-2-Clause` seems to be correct because it matches the `LICENSE` file that was added to the repo :)

[1] https://www.npmjs.com/package/spdx-expression-parse
[2] https://github.com/grncdr/pct-encode/commit/1d461d187337206bae28b8ead022acd056d9729c#r3289609